### PR TITLE
reduce margin-bottom for hover

### DIFF
--- a/Bookmark Toolbar Tweaks/chrome.css
+++ b/Bookmark Toolbar Tweaks/chrome.css
@@ -43,7 +43,7 @@
 @media (-moz-bool-pref: "uc.bookmarks.expand-on-search") or (-moz-bool-pref: "uc.bookmarks.expand-on-hover") {
   #PersonalToolbar[collapsed="false"]:not([customizing]) {
     position: relative;
-    margin-bottom: calc(7px - var(--urlbar-min-height));
+    margin-bottom: calc(-5px - var(--urlbar-min-height));
     transform: rotateX(90deg) !important;
     transform-origin: top;
     transition: transform 135ms linear !important;


### PR DESCRIPTION
Reduces margin to make it look like the default hidden bookmark bar margin, it kinda bugged me that the margin made the main view be below top tab.

Original mod:
![image](https://github.com/user-attachments/assets/d0bfd6a5-47e4-4e2e-b678-15fe9612d51f)

My change:
![image](https://github.com/user-attachments/assets/7cd07311-e365-4d0a-9a32-2580aaa47eea)

Default:
![image](https://github.com/user-attachments/assets/7d71d8b8-aef1-4e99-a488-bb61d4be2a2b)

