### PR TITLE
add and fix features to hide names

### DIFF
--- a/Bookmark Toolbar Tweaks/chrome.css
+++ b/Bookmark Toolbar Tweaks/chrome.css
@@ -36,6 +36,16 @@
   }
 }
 
+/* Hide container labels */
+@media (-moz-bool-pref: "uc.bookmarks.hide-container-name") {
+  #personal-bookmarks .bookmark-item[container] .toolbarbutton-text {
+    display: none !important; 
+  }
+  .bookmark-item[container] .toolbarbutton-icon{
+    margin-inline-end: 0 !important;
+  }
+}
+
 @media (not (-moz-bool-pref: "uc.bookmarks.transparent")) {
     #PersonalToolbar:not([customizing]) {
       margin-bottom: -25px !important; 

--- a/Bookmark Toolbar Tweaks/chrome.css
+++ b/Bookmark Toolbar Tweaks/chrome.css
@@ -28,9 +28,12 @@
 
 /* Hide bookmark labels */
 @media (-moz-bool-pref: "uc.bookmarks.hide-name") {
-    #personal-bookmarks .bookmark-item:not([container]) .toolbarbutton-text { 
-       display: none !important; 
-   }
+  #personal-bookmarks .bookmark-item:not([container]) .toolbarbutton-text {
+    display: none !important; 
+  }
+  .bookmark-item:not([container]) .toolbarbutton-icon{
+    margin-inline-end: 0 !important;
+  }
 }
 
 @media (not (-moz-bool-pref: "uc.bookmarks.transparent")) {

--- a/Bookmark Toolbar Tweaks/preferences.json
+++ b/Bookmark Toolbar Tweaks/preferences.json
@@ -3,6 +3,7 @@
   "uc.bookmarks.hide-folder-icons": "Hide folder icons", 
   "uc.bookmarks.hide-favicons": "Hide website icons",
   "uc.bookmarks.hide-name": "Hide bookmarks name",
+  "uc.bookmarks.hide-container-name": "hide container name",
   "uc.bookmarks.expand-on-hover": "Expand the bookmarks toolbar by hovering",
   "uc.bookmarks.expand-on-search": "Expand the bookmarks toolbar when you search",
   "uc.bookmarks.transparent": "Make the bookmarks toolbar transparent (only works with expand features)" 


### PR DESCRIPTION
Remove the spacing after the icons
going from 
![image](https://github.com/user-attachments/assets/a50fa324-ed16-469c-af21-60b699b6b8c1)
to
![image](https://github.com/user-attachments/assets/30ffaac6-33e9-4b63-bf47-0f311af54c1e)


add the option to hide the icons label with `uc.bookmarks.hide-container-name`
going from
![image](https://github.com/user-attachments/assets/22e75b0d-d492-4d99-8950-8e64e30a7b06)
to
![image](https://github.com/user-attachments/assets/b47a5668-7118-4ba4-a4fa-ed6474a47ae1)

